### PR TITLE
Message Order and Attribute Filter

### DIFF
--- a/pubsubclient/pcspubsub.go
+++ b/pubsubclient/pcspubsub.go
@@ -124,9 +124,18 @@ func (c *PubSubClient) PublishMessage(topicName string, msg CommandMessage) erro
 		return err
 	}
 
-	_, err = topic.Publish(c.ctx, &pubsub.Message{
-		Data: message,
-	}).Get(c.ctx)
+	pubsubMsg := &pubsub.Message{
+		Data:        message,
+		OrderingKey: "1",
+	}
+
+	if msg.Detail != "" {
+		pubsubMsg.Attributes = map[string]string{
+			"origin": msg.Detail,
+		}
+	}
+
+	_, err = topic.Publish(c.ctx, pubsubMsg).Get(c.ctx)
 
 	return err
 }

--- a/readme.md
+++ b/readme.md
@@ -7,16 +7,18 @@
 ## Overview
 
 Internal Use of PCS Pub/Sub service.  
-***Only for PCS Applications***.
+**_Only for PCS Applications_**.
 
 ## Installation
 
 Use `go get` to install the package:
+
 ```
 go get github.com/PCS-Indonesia/pcspubsub/pubsubclient
 ```
 
 ## Command Message
+
 ```
 {
     "command" : "insert|update|delete|notify",
@@ -27,7 +29,6 @@ go get github.com/PCS-Indonesia/pcspubsub/pubsubclient
 ```
 
 ## Examples
-
 
 ### Listen to subscription
 
@@ -61,7 +62,7 @@ func main() {
     message.Command = "command"
     message.Payload = "your json body"
     message.ID      = "id"
-    message.Deatail = "detail"
+    message.Detail = "detail"
     err := pubsubclient.PublishMessage("topic-name", message)
     if err != nil {
         // Error Handling
@@ -70,14 +71,34 @@ func main() {
 ```
 
 ### Test sample
-- Copy credential file to root directory
-- Copy `.env.example` as `.env` and fill it
-- Run pub with
-``` 
+
+-   Copy credential file to root directory
+-   Copy `.env.example` as `.env` and fill it
+-   Run pub with
+
+```
 go run sample.go pub
 ```
-- Run sub with
-``` 
+
+-   Run sub with
+
+```
 go run sample.go sub
 ```
 
+### Message Ordering & Attribute Filter
+
+This package already enables **message ordering** (`OrderingKey`) and **attribute filtering** (`origin`).
+
+To use these features correctly:
+
+-   The **subscriber** must enable **message ordering** in its subscription settings.
+-   The **subscriber** should also configure an **attribute filter** to prevent receiving its own published messages.
+
+Example filter:
+
+```text
+attributes.origin != "apps-2"
+```
+
+In this example, "apps-2" comes from the message.Detail field in the published message.


### PR DESCRIPTION
### Pull Request Title
Add README section for Message Ordering & Attribute Filter configuration

---

### Description
This pull request updates the `README.md` to document that the package now includes:

- **Message Ordering** (`OrderingKey`) support  
- **Attribute Filtering** (`origin`) for subscriber-side message filtering  

The new section explains how to properly configure subscribers to:
- Enable message ordering in their subscription.  
- Add an attribute filter to prevent receiving their own published messages.

---

### Example Added
```
text
attributes.origin != "apps-2"
```

### Screenshot
<img width="902" height="747" alt="image" src="https://github.com/user-attachments/assets/929d7a73-4b38-4388-ac95-6ec6f9b553c4" />
<img width="886" height="257" alt="image" src="https://github.com/user-attachments/assets/5160eaac-530c-40ab-b0dd-aef326716295" />

