### PR TITLE
Fix: enable message order topic

### DIFF
--- a/pubsubclient/pcspubsub.go
+++ b/pubsubclient/pcspubsub.go
@@ -132,6 +132,7 @@ func (c *PubSubClient) PublishMessage(topicName string, msg CommandMessage) erro
 		pubsubMsg.Attributes = msg.Attributes
 	}
 
+	topic.EnableMessageOrdering = true
 	_, err = topic.Publish(c.ctx, pubsubMsg).Get(c.ctx)
 
 	return err


### PR DESCRIPTION
### Pull Request Title
Enable topic message order

---

### Description
- "Error handling: message includes an OrderingKey, but the topic does not have message ordering enabled
---

